### PR TITLE
MDL-55123 forms: do not call non-static methods statically

### DIFF
--- a/periodduration.php
+++ b/periodduration.php
@@ -146,13 +146,13 @@ class format_periods_periodduration extends MoodleQuickForm_group {
         }
         $this->_elements = array();
         // E_STRICT creating elements without forms is nasty because it internally uses $this.
-        $this->_elements[] = @MoodleQuickForm::createElement('text', 'number', get_string('time', 'form'), $attributes, true);
+        $this->_elements[] = $this->createFormElement('text', 'number', get_string('time', 'form'), $attributes, true);
         unset($attributes['size']);
-        $this->_elements[] = @MoodleQuickForm::createElement('select', 'timeunit',
+        $this->_elements[] = $this->createFormElement('select', 'timeunit',
             get_string('timeunit', 'form'), $this->get_units(), $attributes, true);
         // If optional we add a checkbox which the user can use to turn if on.
         if ($this->_options['optional']) {
-            $this->_elements[] = @MoodleQuickForm::createElement('checkbox', 'enabled', null,
+            $this->_elements[] = $this->createFormElement('checkbox', 'enabled', null,
                 get_string('enable'), $this->getAttributes(), true);
         }
         foreach ($this->_elements as $element) {
@@ -171,6 +171,7 @@ class format_periods_periodduration extends MoodleQuickForm_group {
      * @return bool
      */
     public function onQuickFormEvent($event, $arg, &$caller) {
+        $this->setMoodleForm($caller);
         switch ($event) {
             case 'updateValue':
                 // Constant values override both default and submitted ones,


### PR DESCRIPTION
this breaks in PHP7.1